### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.quasar
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 COPY . /app
 
 EXPOSE 8080
-RUN yarn build \
+RUN yarn install \
+  && yarn build \
   && yarn global add @quasar/cli \
   # smoke test
   && quasar --version


### PR DESCRIPTION
# 概要

- `.dockerignore`がなかったのと`Dockerfile`で`yarn install`していなかったせいでデプロイ環境で失敗した
- ローカルで`node_modules`をignoreしていなかったのが原因
- それの修正

## その他

- なし
