### PR TITLE
Contactフォームが送信されたときにSlackに通知する

### DIFF
--- a/src/components/ContactPage/ContactForm.vue
+++ b/src/components/ContactPage/ContactForm.vue
@@ -72,13 +72,6 @@ const STATUS_TYPE = {
   その他: 'cyan',
 };
 
-type TemplateParams = {
-  name: string;
-  email: string;
-  status: keyof typeof STATUS_TYPE;
-  body: string;
-};
-
 export default defineComponent({
   setup() {
     const form = ref<QForm>();
@@ -110,7 +103,7 @@ export default defineComponent({
       async send() {
         loading.value = true;
 
-        const params: TemplateParams = {
+        const params = {
           name: name.value,
           email: email.value,
           status: status.value,

--- a/src/repositories/base_repository.ts
+++ b/src/repositories/base_repository.ts
@@ -1,0 +1,10 @@
+import { AxiosInstance } from 'axios';
+import { api } from 'src/boot/axios';
+
+export abstract class BaseRepository {
+  protected api: AxiosInstance;
+
+  constructor() {
+    this.api = api;
+  }
+}

--- a/src/repositories/emailjs_repository.ts
+++ b/src/repositories/emailjs_repository.ts
@@ -1,0 +1,28 @@
+import { EmailJSResponseStatus, send } from '@emailjs/browser';
+import { BaseRepository } from './base_repository';
+
+export class EmailJSRepository extends BaseRepository {
+  notifyContactForm({
+    name,
+    email,
+    status,
+    body,
+  }: {
+    name: string;
+    email: string;
+    status: string;
+    body: string;
+  }): Promise<EmailJSResponseStatus> {
+    return send(
+      'service_l6niwy4',
+      'template_u36ny2r',
+      {
+        name,
+        email,
+        status,
+        body,
+      },
+      'user_UdBeQl08zUEhs9grdeS90'
+    );
+  }
+}

--- a/src/repositories/slack_repository.ts
+++ b/src/repositories/slack_repository.ts
@@ -1,0 +1,22 @@
+import { BaseRepository } from './base_repository';
+
+export class SlackRepository extends BaseRepository {
+  notifyContactForm({
+    name,
+    email,
+    status,
+    body,
+  }: {
+    name: string;
+    email: string;
+    status: string;
+    body: string;
+  }): Promise<void> {
+    return this.api.post('https://api.ase-lab.space/slack/contact', {
+      name,
+      email,
+      status,
+      body,
+    });
+  }
+}


### PR DESCRIPTION
# 概要

- Contactフォームが送信されたときにSlackに通知
- https://github.com/ase-lab-space/ase-lab-backend/blob/main/routers/slack.go#L16 が対象のendpoint
- バックエンドはGoで作って，https://api.ase-lab.space でデプロイした

## その他

なし
