### PR TITLE
Swap the Slack Repository URL

### DIFF
--- a/src/repositories/slack_repository.ts
+++ b/src/repositories/slack_repository.ts
@@ -13,7 +13,7 @@ export class SlackRepository extends BaseRepository {
     body: string;
   }): Promise<void> {
     return this.api.post(
-      'https://a5osgbixql5fz7bznby76py3iy0hguya.lambda-url.ap-northeast-1.on.aws/',
+      'https://xgmflq3mfb.execute-api.ap-northeast-1.amazonaws.com/default/notifyContactFormSubmission',
       {
         name,
         email,

--- a/src/repositories/slack_repository.ts
+++ b/src/repositories/slack_repository.ts
@@ -12,11 +12,14 @@ export class SlackRepository extends BaseRepository {
     status: string;
     body: string;
   }): Promise<void> {
-    return this.api.post('https://api.ase-lab.space/slack/contact', {
-      name,
-      email,
-      status,
-      body,
-    });
+    return this.api.post(
+      'https://a5osgbixql5fz7bznby76py3iy0hguya.lambda-url.ap-northeast-1.on.aws/',
+      {
+        name,
+        email,
+        status,
+        body,
+      }
+    );
   }
 }


### PR DESCRIPTION
# 概要

フォームのSlack通知用のURLを、張り替える

- https://github.com/ase-lab-space/ase-lab-backend があったが、EC2を使っておりお金がかかるので、AWS Lambdaに乗り換えた
- https://github.com/ase-lab-space/lambda

## その他

なし
