### PR TITLE
Instagramに関してフッターとNewsの追加

### DIFF
--- a/src/components/MainLayout/FooterView.vue
+++ b/src/components/MainLayout/FooterView.vue
@@ -5,6 +5,15 @@
       <a href="https://twitter.com/ASE_lab_" target="_blank" class="icon">
         <q-btn icon="mdi-twitter" flat round />
       </a>
+
+      <a
+        href="https://www.instagram.com/ase__lab/"
+        target="_blank"
+        class="icon"
+      >
+        <q-btn icon="mdi-instagram" flat round />
+      </a>
+
       <a
         href="https://www.facebook.com/ASE.lab.community"
         target="_blank"
@@ -12,6 +21,7 @@
       >
         <q-btn icon="mdi-facebook" flat round />
       </a>
+
       <a
         href="https://github.com/ase-lab-space/ase-lab"
         target="_blank"

--- a/src/i18n/en-US/news.ts
+++ b/src/i18n/en-US/news.ts
@@ -7,4 +7,8 @@ export default {
     title: 'Seminar Guidebook on ASE-Lab. Ver.2 is published.',
     tag: 'Notice',
   },
+  news3: {
+    title: 'We ASE-Lab. created our Instagram account.',
+    tag: 'Notice',
+  },
 };

--- a/src/i18n/ja-JP/news.ts
+++ b/src/i18n/ja-JP/news.ts
@@ -7,4 +7,8 @@ export default {
     title: 'ASE-Lab. ゼミガイドブックver2が公開されました。',
     tag: 'お知らせ',
   },
+  news3: {
+    title: 'ASE-Lab. 公式Instagramが開設されました。',
+    tag: 'お知らせ',
+  },
 };

--- a/src/models/news.ts
+++ b/src/models/news.ts
@@ -33,4 +33,10 @@ export const news: INews[] = [
     date: '2023.02.24',
     url: '/pdf/ASE-Lab. ガイドブック.pdf',
   },
+  {
+    title: $t('news.news3.title'),
+    tag: 'お知らせ',
+    date: '2023.03.24',
+    url: 'https://www.instagram.com/ase__lab/',
+  },
 ];


### PR DESCRIPTION
# 概要

ホームページのフッターにインスタグラムのアイコンを設置
News欄のお知らせにインスタグラムの開設を記述

## その他
3/24にTwitterで開設告知を忘れずにさせる
