### PR TITLE
測定のためにclarityを導入

### DIFF
--- a/src/index.template.html
+++ b/src/index.template.html
@@ -46,6 +46,20 @@
 
       gtag('config', 'G-4MQDJGDT4X');
     </script>
+    <script type="text/javascript">
+      (function (c, l, a, r, i, t, y) {
+        c[a] =
+          c[a] ||
+          function () {
+            (c[a].q = c[a].q || []).push(arguments);
+          };
+        t = l.createElement(r);
+        t.async = 1;
+        t.src = 'https://www.clarity.ms/tag/' + i;
+        y = l.getElementsByTagName(r)[0];
+        y.parentNode.insertBefore(t, y);
+      })(window, document, 'clarity', 'script', 'hsbokm0hcb');
+    </script>
   </head>
   <body>
     <div id="q-app"></div>


### PR DESCRIPTION
# 概要

clarityを導入
- ヒートマップや、実際にウェブサイトを見ている人の画面録画が確認できるようになる
- ウェブサイトの改善のために入れる

## その他

なし
