### PR TITLE
問い合わせフォームのSlack通知API EndpointをVercelにする

### DIFF
--- a/src/components/ContactPage/ContactForm.vue
+++ b/src/components/ContactPage/ContactForm.vue
@@ -37,28 +37,14 @@ ja:
             :dense="q.screen.lt.sm"
           />
           <div class="q-gutter-sm">
-            <div v-if="q.screen.gt.xs">
-              <q-radio
-                v-for="(color, s) in STATUS_TYPE"
-                :key="s"
-                v-model="status"
-                :val="s"
-                :label="t(s)"
-                :color="color"
-                :rules="[rules.required]"
-              />
-            </div>
-            <q-select
-              v-else
+            <q-radio
+              v-for="(color, s) in STATUS_TYPE"
+              :key="s"
               v-model="status"
-              :options="
-                Object.keys(STATUS_TYPE).map((key) => ({
-                  value: key,
-                  label: t(key),
-                }))
-              "
-              label="職業"
-              dense
+              :val="s"
+              :label="t(s)"
+              :color="color"
+              :rules="[rules.required]"
             />
           </div>
           <q-input

--- a/src/repositories/slack_repository.ts
+++ b/src/repositories/slack_repository.ts
@@ -12,14 +12,11 @@ export class SlackRepository extends BaseRepository {
     status: string;
     body: string;
   }): Promise<void> {
-    return this.api.post(
-      'https://xgmflq3mfb.execute-api.ap-northeast-1.amazonaws.com/default/notifyContactFormSubmission',
-      {
-        name,
-        email,
-        status,
-        body,
-      }
-    );
+    return this.api.post('https://api.ase-lab.space/api/contact', {
+      name,
+      email,
+      status,
+      body,
+    });
   }
 }


### PR DESCRIPTION
# 概要

問い合わせ通知を、新たに作ったapiリポジトリ（Vercelの Serverless Functions でデプロイ済み）にPOSTするようにする
- https://github.com/ase-lab-space/api

経緯:
今まではAWSのLambdaを使っていた。俗人的なので、無料で使えるVercel Serverless Functionsに移行する。

related: #98

## その他

テスト: https://ase-labhq.slack.com/archives/C03UULHRL8Y/p1690123927381409
