### PR TITLE
問い合わせフォーム送信者に確認メールを送る

### DIFF
--- a/src/components/ContactPage/ContactForm.vue
+++ b/src/components/ContactPage/ContactForm.vue
@@ -76,6 +76,7 @@ import { useI18n } from 'vue-i18n';
 import { QForm, useQuasar } from 'quasar';
 import { SlackRepository } from 'src/repositories/slack_repository';
 import { EmailJSRepository } from 'src/repositories/emailjs_repository';
+import { GASRepository } from 'src/repositories/gas_repository';
 
 const STATUS_TYPE = {
   highSchool: 'teal',
@@ -88,7 +89,9 @@ export default defineComponent({
   setup() {
     const form = ref<QForm>();
     const q = useQuasar();
-    const { t } = useI18n();
+    const { t, locale } = useI18n();
+
+    console.log(locale.value);
 
     const name = ref('');
     const email = ref('');
@@ -131,11 +134,16 @@ export default defineComponent({
 
         const slackRepository = new SlackRepository();
         const emailjsRepository = new EmailJSRepository();
+        const gasRepository = new GASRepository();
 
         try {
           await Promise.all([
             slackRepository.notifyContactForm(params),
             emailjsRepository.notifyContactForm(params),
+            gasRepository.sendConfirmationEmail({
+              ...params,
+              locale: locale.value,
+            }),
           ]);
         } catch {
           q.notify(

--- a/src/repositories/gas_repository.ts
+++ b/src/repositories/gas_repository.ts
@@ -1,0 +1,25 @@
+import { BaseRepository } from './base_repository';
+
+const endpoint =
+  'https://script.google.com/macros/s/AKfycbz4np5rSyNA5qL5fXZI9V0Z0SjqINKUBG6t3cYMeCCXibSPR6ilNbeGT6O14wzGyYv-/exec';
+
+export class GASRepository extends BaseRepository {
+  sendConfirmationEmail({
+    name,
+    email,
+    body,
+    locale,
+  }: {
+    name: string;
+    email: string;
+    body: string;
+    locale: string;
+  }) {
+    const params = new URLSearchParams();
+    params.append('name', name);
+    params.append('email', email);
+    params.append('body', body);
+    params.append('locale', locale);
+    return this.api.post(endpoint, params);
+  }
+}


### PR DESCRIPTION
# 概要

問い合わせフォーム送信者に対して、自動返信メールを送信する。

GAS を用いて、ase.lab.academic@gmail.com からの自動返信メールを送信
スクリプト: https://script.google.com/home/projects/1LGuOEjg6GuhkN7TdazLVqUQvdVx1IO7JX-5l6iJAodHEeG_55Fc7GOHr/edit

## その他

なし
